### PR TITLE
ci(workflow): 升级 GitHub Actions 移除 Node.js 12 弃用警告

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,23 +26,23 @@ jobs:
           - 8.12.2
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     -
       name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
     -
       name: Login to DockerHub
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     -
       name: Build and push
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         push: true
         context: .


### PR DESCRIPTION
- actions/checkout: v2 -> v4
- docker/setup-qemu-action: v1 -> v3
- docker/setup-buildx-action: v1 -> v3
- docker/login-action: v1 -> v3
- docker/build-push-action: v2 -> v6

所有 action 现已运行在 Node.js 20，GitHub Actions 将不再输出 Node.js 12 弃用警告。